### PR TITLE
Updated outdated links for JNLPBA dataset

### DIFF
--- a/ner_scripts/download_files.py
+++ b/ner_scripts/download_files.py
@@ -213,9 +213,9 @@ if __name__ == '__main__':
 
     # JNLPBA
     if is_empty('jnlpba'):
-        urlretrieve('http://www.nactem.ac.uk/tsujii/GENIA/ERtask/Genia4ERtraining.tar.gz',
+        urlretrieve('http://www.nactem.ac.uk/GENIA/current/Shared-tasks/JNLPBA/Train/Genia4ERtraining.tar.gz',
                     'genia_train.tar.gz')
-        urlretrieve('http://www.nactem.ac.uk/tsujii/GENIA/ERtask/Genia4ERtest.tar.gz',
+        urlretrieve('http://www.nactem.ac.uk/GENIA/current/Shared-tasks/JNLPBA/Evaluation/Genia4ERtest.tar.gz',
                     'genia_test.tar.gz')
         with tarfile.open('genia_train.tar.gz') as f:
             f.extractall(os.path.join(data_dir, 'jnlpba'))


### PR DESCRIPTION
The links for the JNLPBA 2004 dataset seemed to be outdated and led to a non-existing webpage. I have updated the links after having browsed through the website at:
http://www.geniaproject.org/shared-tasks/bionlp-jnlpba-shared-task-2004