### PR TITLE
Updates to the BioCreative website

### DIFF
--- a/ner_scripts/download_files.py
+++ b/ner_scripts/download_files.py
@@ -302,11 +302,11 @@ if __name__ == '__main__':
 
     # CDR
     if is_empty('CDR_Data'):
-        raise ValueError("Please download the data from http://www.biocreative.org/tasks/biocreative-v/track-3-cdr/ and move the extracted directory to data/ ...")
+        raise ValueError("Please download the data from https://biocreative.bioinformatics.udel.edu/resources/corpora/biocreative-v-cdr-corpus/ and move the extracted directory to data/ ...")
 
     # Biocreative
     if is_empty('bc2gm/train') or is_empty('bc2gm/test'):
-        raise ValueError("Please download the train and test data for the GM subtask from http://www.biocreative.org/resources/corpora/biocreative-ii-corpus/ and place the directories named 'train' and 'test' into data/bc2gm ...")
+        raise ValueError("Please download the train and test data for the GM subtask from https://biocreative.bioinformatics.udel.edu/resources/corpora/biocreative-ii-corpus/ and place the directories named 'train' and 'test' into data/bc2gm ...")
 
 
     print("Success! All corpora should now be available.")


### PR DESCRIPTION
It seems that the entire BioCreative website has moved 
from  
https://www.biocreative.org/
to 
https://biocreative.bioinformatics.udel.edu/

Accordingly, I have updated the links to CDR and BioCreative datasets which now point to the new domain.

Additionally, it seems that the new website itself has not updated the links to its resources (and still points to the non-functional biocreative.org website). Thus, it may be required to make this substitution for anyone wishing to browse the website.