### PR TITLE
Added lxml installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -o $OPENNLP/models/en-token.bin http://opennlp.sourceforge.net/models-1
 RUN pip install --upgrade pip
 RUN pip install --upgrade six
 RUN pip install --upgrade --no-deps git+git://github.com/Theano/Theano.git
-RUN pip install joblib gunicorn flask pexpect
+RUN pip install joblib gunicorn flask pexpect lxml
 
 EXPOSE 5000:5000
 


### PR DESCRIPTION
Seems like building from Docker file and directly running convert_corpora.sh results in "No module named lxml" error. Not sure if a default python Ubuntu installation already has lxml